### PR TITLE
And SIA code to reflect Unset status

### DIFF
--- a/pyspcwebgw/area.py
+++ b/pyspcwebgw/area.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class Area:
     """Represents and SPC alarm system area."""
-    SUPPORTED_SIA_CODES = ('CG', 'NL', 'OG', 'BV')
+    SUPPORTED_SIA_CODES = ('CG', 'NL', 'OG', 'BV', 'OQ')
 
     def __init__(self, gateway, spc_area):
         self._gateway = gateway


### PR DESCRIPTION
I've experienced the same issue as listed in #2. By quickly running an SPC-Gateway debugger I figured that when disarming the panel SIA code returned by the panel is: `OQ`. Since we don't have that code in `SUPPORTED_SIA_CODES`, the update of Area status gets skipped [here](https://github.com/mbrrg/pyspcwebgw/blob/d6a55beb131c0fab2072b4ef560720b572300269/pyspcwebgw/__init__.py#L107-L109).

This change proposes to add `OQ` SIA code. Here's the return from the panel during unsetting:

SPC app:
```
{"status":"success","data":{"sia":{"device_id":"1000","timestamp":"1603057827","sia_code":"OQ","sia_address":"2","description":"Vova","flags":"","verification_id":"0"}}}
```

HomeKit app:
```
{"status":"success","data":{"sia":{"device_id":"1000","timestamp":"1603057719","sia_code":"OQ","sia_address":"9998","description":"Remote Engineer","flags":"","verification_id":"0"}}}
```