### PR TITLE
Quickdraft supporting Flex Gateway in non-authoritive config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Examples of available commands in the test shell:
 - ```part_set_x```. Part set x an area.
 - ```unset```. Unset an area.
 - ```debug```. Toggle debug output.
+
+## Flex Gateway
+
+While initially written for SPC Web Gateway you can use this for SPC Flex Gateway as well.
+
+There is a (big!) security caveat though, you can't enable login for `get_user` in the Flex Gateway `config.xml`.

--- a/pyspcwebgw/__init__.py
+++ b/pyspcwebgw/__init__.py
@@ -61,8 +61,7 @@ class SpcWebGateway:
 
         for spc_area in areas:
             area = Area(self, spc_area)
-            area_zones = [Zone(area, z) for z in zones
-                          if z['area'] == spc_area['id']]
+            area_zones = [Zone(area, z) for z in zones if (z.get('area',False) == spc_area.get('id',True) or z.get('area_id',False) == spc_area.get('area_id',True))]
             area.zones = area_zones
             self._areas[area.id] = area
             self._zones.update({z.id: z for z in area_zones})
@@ -92,7 +91,7 @@ class SpcWebGateway:
 
     async def _async_ws_handler(self, data):
         """Process incoming websocket message."""
-        sia_message = data['data']['sia']
+        sia_message = data['data'].get('sia',data['data'].get('event'))
         spc_id = sia_message['sia_address']
         sia_code = sia_message['sia_code']
 
@@ -124,8 +123,18 @@ class SpcWebGateway:
         else:
             url = urljoin(self._api_url, "spc/{}".format(resource))
         data = await async_request(self._session.get, url)
+
         if not data:
             return False
+
+        flexgw_resources= {
+            "panel": "panel_summary",
+            "zone": "zone_status",
+            "area": "area_status",
+        }
+        if not data['data'].get(resource):
+          resource=flexgw_resources.get(resource, resource)
+
         if id and isinstance(data['data'][resource], list):
             # for some reason the gateway returns an array with a single
             # element for areas but not for zones...

--- a/pyspcwebgw/area.py
+++ b/pyspcwebgw/area.py
@@ -12,10 +12,11 @@ class Area:
 
     def __init__(self, gateway, spc_area):
         self._gateway = gateway
-        self._id = spc_area['id']
-        self._name = spc_area['name']
         self._verified_alarm = False
         self.zones = None
+
+        self._id = spc_area.get('id',spc_area.get('area_id'))
+        self._name = spc_area.get('name',spc_area.get('area_name'))
 
         self.update(spc_area)
 

--- a/pyspcwebgw/zone.py
+++ b/pyspcwebgw/zone.py
@@ -12,7 +12,7 @@ class Zone:
                            'BB', 'BU', 'BR', 'BC')
 
     def __init__(self, area, spc_zone):
-        self._id = spc_zone['id']
+        self._id = spc_zone.get('id',spc_zone.get('zone_id'))
         self._name = spc_zone['zone_name']
         self._area = area
 


### PR DESCRIPTION
Not meant as a full PR just yet (i.e. missing tests et such), but with minor adjustments (the Flex GW seems to have prefixed `id` and `name` and the Web's `sia` looks like `event` now).

The caveat though, FlexGW in authenticated mode (`get_user` and `ws_user` with their own passwords) must use HTTPDigestAuthentication which is not supported by `aiohttp`.

For now this is 'works on a customer environment' (all the way up to your HA component).