### PR TITLE
implement stop() for SpcWebGateway

### DIFF
--- a/pyspcwebgw/__init__.py
+++ b/pyspcwebgw/__init__.py
@@ -50,6 +50,11 @@ class SpcWebGateway:
                                       async_callback=self._async_ws_handler)
         self._websocket.start()
 
+    def stop(self):
+        """Disconnect websocket to SPC Web Gateway."""
+        self._websocket.stop()
+        self._websocket = None
+
     async def async_load_parameters(self):
         """Fetch area and zone info from SPC to initialize."""
         self._info = await self._async_get_data('panel')

--- a/pyspcwebgw/websocket.py
+++ b/pyspcwebgw/websocket.py
@@ -25,6 +25,7 @@ class AIOWSClient:
         self._async_callback = async_callback
         self._data = None
         self._state = None
+        self._task = None
 
     @property
     def data(self):
@@ -44,7 +45,7 @@ class AIOWSClient:
     def start(self):
         if self.state != STATE_RUNNING:
             self.state = STATE_STARTING
-        self._loop.create_task(self.running())
+        self._task = self._loop.create_task(self.running())
 
     async def running(self):
         """Start websocket connection."""
@@ -74,6 +75,8 @@ class AIOWSClient:
     def stop(self):
         """Close websocket connection."""
         self.state = STATE_STOPPED
+        if self._task:
+            self._task.cancel()
 
     def retry(self):
         """Retry to connect to SPC."""


### PR DESCRIPTION
In order to remove the SPC component from during runtime, we need to be able stop stop the web service client, including cancelling any running tasks in `AIOWSClient`.

A new release once/if this PR is merged would be appreciated, needed to add config flow to the Home Assistant SPC component.